### PR TITLE
Fetch/verify ERC-20 contract balances for light client wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@chainsafe/persistent-merkle-tree": "^0.3.7",
     "@chainsafe/ssz": "^0.8.20",
     "@ethereumjs/vm": "^5.7.1",
+    "@ethersproject/abi": "^5.6.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/AccountHelper.tsx
+++ b/src/AccountHelper.tsx
@@ -1,0 +1,180 @@
+import React, {useEffect, useMemo, useState} from "react";
+import {ErrorView} from "./components/ErrorView";
+
+export type ERC20Contract = {
+  contractAddress: string;
+  balanceMappingIndex: number;
+};
+
+enum FormAction {
+  Form = "form",
+  Action = "action",
+}
+
+export type NewContract = {
+  state: FormAction;
+  data: {name: string} & ERC20Contract;
+  error?: Error;
+};
+
+export type ParsedAccount = {
+  type: string;
+  balance: string;
+  nonce: string;
+  verified: boolean;
+  tokens: {name: string; balance: string; contractAddress: string}[];
+};
+
+function defaultNewContract(): NewContract {
+  return {
+    state: FormAction.Action,
+    data: {name: "", contractAddress: "", balanceMappingIndex: 0},
+  };
+}
+
+export function DisplayAccount({
+  account,
+  erc20Contracts,
+  setErc20Contracts,
+}: {
+  account: ParsedAccount;
+  erc20Contracts: Record<string, ERC20Contract>;
+  setErc20Contracts: (_records: Record<string, ERC20Contract>) => void;
+}): JSX.Element {
+  return (
+    <>
+      <DisplayBalance name={"Ether"} contractAddress={""} balance={account.balance} />
+      {account.tokens.map((token) => (
+        <DisplayBalance
+          {...token}
+          removeToken={(tokenName) => {
+            delete erc20Contracts[tokenName];
+            setErc20Contracts({...erc20Contracts});
+          }}
+        />
+      ))}
+      <NewContract erc20Contracts={erc20Contracts} setErc20Contracts={setErc20Contracts} />
+    </>
+  );
+}
+
+export function DisplayBalance({
+  name,
+  balance,
+  contractAddress,
+  removeToken,
+}: {
+  name: string;
+  balance: string;
+  contractAddress?: string;
+  removeToken?: (_name: string) => void;
+}): JSX.Element {
+  return (
+    <>
+      <div className="displaybalance">
+        <div
+          className="remove"
+          onClick={() => {
+            if (removeToken) removeToken(name);
+          }}
+        >
+          {removeToken && "✖️"}
+        </div>
+        <div className="balance">
+          <input value={balance} disabled={true} />
+        </div>
+        <div className="name">
+          <div>{name}</div>
+        </div>
+      </div>
+      <div className="displaycontract">{contractAddress && ` (${contractAddress})`}</div>
+    </>
+  );
+}
+
+function NewContract({
+  erc20Contracts,
+  setErc20Contracts,
+}: {
+  erc20Contracts: Record<string, ERC20Contract>;
+  setErc20Contracts: (_records: Record<string, ERC20Contract>) => void;
+}): JSX.Element {
+  const [newContract, setNewContract] = useState<NewContract>(defaultNewContract());
+
+  return (
+    <>
+      {newContract.state === FormAction.Action ? (
+        <span
+          className="addcontractaction"
+          onClick={() => {
+            setNewContract({...newContract, state: FormAction.Form});
+          }}
+        >
+          {"➕"}
+        </span>
+      ) : (
+        <div>
+          <p>Token Name</p>
+          <input
+            value={newContract.data.name}
+            onChange={(e) => {
+              newContract.data.name = e.target.value;
+              setNewContract({...newContract});
+            }}
+          />
+          <p>Contract Address</p>
+          <input
+            value={newContract.data.contractAddress}
+            onChange={(e) => {
+              newContract.data.contractAddress = e.target.value;
+              setNewContract({...newContract});
+            }}
+          />
+          <p>Balance Mapping Index</p>
+          <input
+            value={newContract.data.balanceMappingIndex}
+            onChange={(e) => {
+              newContract.data.balanceMappingIndex = parseInt(`0${e.target.value}`);
+              setNewContract({...newContract});
+            }}
+          />
+          <div>
+            <span
+              className="addcontractaction"
+              onClick={() => {
+                if (newContract.data.name === "") {
+                  setNewContract({
+                    ...newContract,
+                    error: Error("Invalid name, please provide a valid token name"),
+                  });
+                  return;
+                }
+                const hexPattern = new RegExp(/^(0x|0X)?(?<tokenHex>[a-fA-F0-9]{40})$/, "g");
+                if (!hexPattern.exec(newContract.data.contractAddress)?.groups?.tokenHex) {
+                  setNewContract({...newContract, error: Error("Invalid contract address")});
+                  return;
+                }
+
+                if (newContract.data.name != "" && newContract.data.contractAddress != "") {
+                  setErc20Contracts({...erc20Contracts, [newContract.data.name]: newContract.data as ERC20Contract});
+                }
+                setNewContract(defaultNewContract());
+              }}
+            >
+              {"✔️"}
+            </span>
+            <span
+              className="addcontractaction"
+              onClick={() => {
+                setNewContract(defaultNewContract());
+              }}
+            >
+              {"✖️"}
+            </span>
+            {newContract.error && <ErrorView error={newContract.error} />}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ function getNetworkUrl(network: string) {
   } else if (network === "prater") {
     return {beaconApiUrl: "https://prater.lodestar.casa", elRpcUrl: "https://praterrpc.lodestar.casa"};
   } else {
-    return {beaconApiUrl: "http://kiln.lodestar.casa:30352", elRpcUrl: "http://kiln.lodestar.casa:31122"};
+    return {beaconApiUrl: "http://kiln.lodestar.casa:31890", elRpcUrl: "http://kiln.lodestar.casa:30995"};
   }
 }
 
@@ -118,7 +118,7 @@ export default function App(): JSX.Element {
   const [address, setAddress] = useState<string>("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
   const [accountReqStatus, setAccountReqStatus] = useState<ReqStatus<ParsedAccount, string>>({});
   const [erc20Contracts, setErc20Contracts] = useState<Record<string, ERC20Contract>>({
-    DAI: {contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F", balanceMappingIndex: 2},
+    DAI: {contractAddress: "0x7b4343e96fa21413a8e5A15D67b529D2B9495437", balanceMappingIndex: 2},
   });
   const web3 = useRef<Web3>();
 
@@ -496,8 +496,8 @@ async function fetchAndVerifyAddressBalances({
     const contractProofStateRoot = toHexString(keccak256(toBuffer(contractProof.accountProof[0])));
     // Verify the proof, web3 converts nonce and balance into number strings, however
     // ethereumjs verify proof requires them in the original hex format
-    contractProof.nonce = numberToHex(proof.nonce);
-    contractProof.balance = numberToHex(proof.balance);
+    contractProof.nonce = numberToHex(contractProof.nonce);
+    contractProof.balance = numberToHex(contractProof.balance);
 
     verified =
       verified &&

--- a/src/Networks.tsx
+++ b/src/Networks.tsx
@@ -1,0 +1,99 @@
+import {networkGenesis} from "@chainsafe/lodestar-light-client/lib/networks";
+import {networksChainConfig} from "@chainsafe/lodestar-config/networks";
+import {getClient} from "@chainsafe/lodestar-api";
+import {config as configDefault} from "@chainsafe/lodestar-config/default";
+import {toHexString} from "@chainsafe/ssz";
+import {createIChainForkConfig, chainConfigFromJson} from "@chainsafe/lodestar-config";
+
+export enum NetworkName {
+  mainnet = "mainnet",
+  prater = "prater",
+  kiln = "kiln",
+  custom = "custom",
+}
+export const networkDefault = NetworkName.kiln;
+
+export type ERC20Contract = {
+  contractAddress: string;
+  balanceMappingIndex: number;
+};
+
+export async function getNetworkData(network: NetworkName, beaconApiUrl?: string) {
+  switch (network) {
+    case NetworkName.mainnet:
+    case NetworkName.prater:
+      return {
+        genesisData: networkGenesis[network],
+        chainConfig: networksChainConfig[network],
+      };
+
+    case NetworkName.kiln:
+    default:
+      if (!beaconApiUrl) {
+        throw Error(`Unknown network: ${network}, requires beaconApiUrl to load config`);
+      }
+      const api = getClient(configDefault, {baseUrl: beaconApiUrl});
+      const {data: genesisData} = await api.beacon.getGenesis();
+      const {data: chainConfig} = await api.config.getSpec();
+      const networkData = {
+        genesisData: {
+          genesisTime: Number(genesisData.genesisTime),
+          genesisValidatorsRoot: toHexString(genesisData.genesisValidatorsRoot),
+        },
+        chainConfig: chainConfigFromJson(chainConfig),
+      };
+      return networkData;
+  }
+}
+
+export const defaultNetworkUrls: Record<NetworkName, {beaconApiUrl: string; elRpcUrl: string}> = {
+  [NetworkName.mainnet]: {beaconApiUrl: "https://mainnet.lodestar.casa", elRpcUrl: "https://mainnet.lodestar.casa"},
+  [NetworkName.prater]: {beaconApiUrl: "https://prater.lodestar.casa", elRpcUrl: "https://praterrpc.lodestar.casa"},
+  [NetworkName.kiln]: {beaconApiUrl: "https://kiln.lodestar.casa", elRpcUrl: "https://kilnrpc.lodestar.casa"},
+  [NetworkName.custom]: {beaconApiUrl: "", elRpcUrl: ""},
+};
+
+export enum DefaultTokens {
+  DAI = "DAI",
+}
+export const DefaultTokensMeta: Record<
+  DefaultTokens,
+  {balanceMappingIndex: number; addresses: Partial<Record<NetworkName, string>>}
+> = {
+  [DefaultTokens.DAI]: {
+    balanceMappingIndex: 2,
+    addresses: {[NetworkName.custom]: "0x7b4343e96fa21413a8e5A15D67b529D2B9495437"},
+  },
+};
+
+export function getNetworkTokens(network: NetworkName, includePartial: boolean = false): Record<string, ERC20Contract> {
+  const tokens: Record<string, ERC20Contract> = {};
+  for (const [tokenName, tokenMeta] of Object.entries(DefaultTokensMeta)) {
+    if (tokenMeta.addresses[network] !== undefined || includePartial) {
+      tokens[tokenName] = {
+        balanceMappingIndex: tokenMeta.balanceMappingIndex,
+        contractAddress: tokenMeta.addresses[network] ?? "",
+      };
+    }
+  }
+  return tokens;
+}
+
+export const defaultNetworkTokens: Record<
+  NetworkName,
+  {full: Record<string, ERC20Contract>; partial: Record<string, ERC20Contract>}
+> = {
+  [NetworkName.mainnet]: {
+    full: getNetworkTokens(NetworkName.mainnet),
+    partial: getNetworkTokens(NetworkName.mainnet, true),
+  },
+  [NetworkName.prater]: {
+    full: getNetworkTokens(NetworkName.prater),
+    partial: getNetworkTokens(NetworkName.prater, true),
+  },
+  [NetworkName.kiln]: {full: getNetworkTokens(NetworkName.kiln), partial: getNetworkTokens(NetworkName.kiln, true)},
+  [NetworkName.custom]: {
+    full: getNetworkTokens(NetworkName.custom),
+    partial: getNetworkTokens(NetworkName.custom, true),
+  },
+};

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -259,6 +259,28 @@ section > .field:not(:last-child) {
 .account {
   display: flex;
   max-width: 33rem;
+  .address {
+    width: 70%;
+    margin-right: 1rem;
+  }
+  .result{
+    width: 30%;
+    display: flex;
+    span {
+      opacity: 0.5;
+    }
+    .nonce{
+      margin-right: 1rem;
+    }
+    .icon{
+      padding-top: 1.8rem;
+    }
+  }
+}
+
+.displaybalance {
+  display: flex;
+  max-width: 33rem;
   .balance {
     width: 35%;
     margin-right: 1rem;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -280,21 +280,44 @@ section > .field:not(:last-child) {
 
 .displaybalance {
   display: flex;
+  flex-direction: row-reverse;
   max-width: 33rem;
-  .balance {
-    width: 35%;
-    margin-right: 1rem;
+  margin-bottom: 0rem;
+  .empty{
+    width: 60%;
   }
-  .nonce{
-    width: 25%;
-    margin-right: 1rem;
-  }
-  .status{
-    width: 25%;
-    margin-right: 1rem;
-  }
-  .icon{
+  .name {
     width: 10%;
-    margin-top: 1.5em;
+    margin-right: 1rem;
+    margin-top: 0.4em;
+  }
+  .balance{
+    width: 30%;
+  }
+  .remove{
+    width: 5%;
+    cursor: pointer;
+    &:hover {
+      opacity: 1;
+    }
   }
 }
+
+.displaycontract {
+    max-width: 33rem;
+    opacity: 0.5;
+    margin-left: 0.5rem;
+    font-size: 85%;
+    overflow: hidden;
+    text-align: right;
+  }
+
+.addcontractaction {
+    margin-left: 0.5rem;
+    margin-right: 1rem;
+    font-size: 3rem;
+    cursor: pointer;
+    &:hover {
+      opacity: 1;
+    }
+  }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2144,6 +2144,21 @@
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
 
+"@ethersproject/abi@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.6.0.tgz#ea07cbc1eec2374d32485679c12408005895e9f3"
+  integrity sha512-AhVByTwdXCc2YQ20v300w6KVHle9g2OFc28ZAFCPnJyEpkv1xKXjZcSTgWOlv1i+0dqlgF8RCF2Rn2KC1t+1Vg==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
 "@ethersproject/abstract-provider@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz#0c4ac7054650dbd9c476cf5907f588bbb6ef3061"
@@ -2209,7 +2224,7 @@
   dependencies:
     "@ethersproject/bignumber" "^5.6.0"
 
-"@ethersproject/hash@^5.0.4":
+"@ethersproject/hash@^5.0.4", "@ethersproject/hash@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.6.0.tgz#d24446a5263e02492f9808baa99b6e2b4c3429a2"
   integrity sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==


### PR DESCRIPTION
**Motivation**
Light client post merge, can also fetch and verify any token balances for the contracts who's balance mapping structure is known. For well know  contracts this can be figured out.

<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR adds the capability to allow fetching,verifying and displaying ERC-20 contract balances for any ethereum address. It seeds balance mapping structure for some well know contracts.


TODOs
- [x] Investigate and fix why verify proof is failing on the token data
- [x] Deploy an ERC 20 contract on kiln and mint some token to an addresse and get the correct balance onto the lightclient display
- [x] fix the account and token balances display
- [x] figureout and seed data for some well know contracts
- [x] allow adding any token with `address` => `uint` balances mapping
**Description**
Example fetch of an ERC 20 contract balance:

![image](https://user-images.githubusercontent.com/76567250/158888525-413f0688-3b91-4c68-92bd-826c3073a984.png)

