### PR TITLE
Kiln url fixes and hex pattern check for token

### DIFF
--- a/src/AccountHelper.tsx
+++ b/src/AccountHelper.tsx
@@ -175,7 +175,7 @@ function NewContract({
                   });
                   return;
                 }
-                const hexPattern = new RegExp(/^(0x|0X)?(?<tokenHex>[a-fA-F0-9]{40})$/, "g");
+                const hexPattern = new RegExp(/^(0x|0X)?(?<tokenHex>[a-fA-F0-9]{40})$/);
                 if (!hexPattern.exec(newContract.data.contractAddress)?.groups?.tokenHex) {
                   setNewContract({...newContract, error: Error("Invalid contract address")});
                   return;

--- a/src/Networks.tsx
+++ b/src/Networks.tsx
@@ -56,8 +56,8 @@ export const defaultNetworkUrls: Record<NetworkName, {beaconApiUrl: string; elRp
     elRpcUrl: process.env.REACT_APP_PRATER_EXECUTION_API || "https://lodestar-praterrpc.chainsafe.io",
   },
   [NetworkName.kiln]: {
-    beaconApiUrl: process.env.REACT_APP_KILN_BEACON_API || "https://lodestar-kiln.chainsafe.io/",
-    elRpcUrl: process.env.REACT_APP_KILN_EXECUTION_API || "https://lodestar-kilnrpc.chainsafe.io/",
+    beaconApiUrl: process.env.REACT_APP_KILN_BEACON_API || "https://lodestar-kiln.chainsafe.io",
+    elRpcUrl: process.env.REACT_APP_KILN_EXECUTION_API || "https://lodestar-kilnrpc.chainsafe.io",
   },
   [NetworkName.custom]: {beaconApiUrl: "", elRpcUrl: ""},
 };


### PR DESCRIPTION
**Motivation**
Remove extra `\` for kiln urls (it gets appended with another 
`\` while building the url for requests) which doesn't work in fetching sse update and remove `g` option for hex pattern match for token validity.

