### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,10 @@
 # the repo. Unless a later match takes precedence,
 # They will be requested for
 # review when someone opens a pull request.
-*       @wemeetagain @mpetrunic @tuyennhv @dapplion
+*       @ChainSafe/lodestar
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
 # modifies md files, only md owners and not the global
 # owner(s) will be requested for a review.
-*.md    @RyRy79261 @ColinSchwarz @wemeetagain @mpetrunic @tuyennhv @dapplion
+*.md    @ChainSafe/lodestar


### PR DESCRIPTION
This PR updates codeowners to Lodestar team members of the ChainSafe org for scaling purposes.