### PR TITLE
fix: show data from path to array element

### DIFF
--- a/src/ProofReqResp.tsx
+++ b/src/ProofReqResp.tsx
@@ -124,11 +124,15 @@ function renderState(paths: Path[], state: TreeBackedState): StateRender {
 }
 
 function getStateData(state: TreeBackedState, path: Path): string {
-  let value = state as object;
+  let value = state as Record<string, any>;
   let type = state.type as CompositeType<object, unknown, unknown>;
   for (const indexer of path) {
     type = type.getPropertyType(indexer) as CompositeType<object, unknown, unknown>;
-    value = (value as Record<string, unknown>)[String(indexer)] as object;
+    if (value["get"] !== undefined) {
+      value = value.get(String(indexer)) as object;
+    } else {
+      value = value[String(indexer)] as object;
+    }
   }
   try {
     return JSON.stringify(type.toJson(value.valueOf()), null, 2);


### PR DESCRIPTION
**Motivation**

Fixes the issue where some path in the state created from the proof show as undefined even when they are present. 

**Description**

When the ssz type is list-like, using the object property indexing does not work. The _get_ method is used instead.

it works now as can be seen from screenshot:

<!-- If applicable, add screenshots to help explain your solution -->
<img width="1236" alt="Screenshot 2022-07-30 at 04 43 25" src="https://user-images.githubusercontent.com/272535/181871178-cd0f21d6-c5e9-4e63-b358-212cd11804f6.png">

Closes #39